### PR TITLE
Fix language cookie expiration calculation in SettingsPage: update langCookieExpirationDate to directly use the expiration duration in milliseconds for improved clarity and correctness.

### DIFF
--- a/src/components/SideNavbar/SettingsPage.js
+++ b/src/components/SideNavbar/SettingsPage.js
@@ -47,7 +47,7 @@ function SettingsPage({
             document.documentElement.lang = newLanguage;
 
             // 365 days in minutes
-            const langCookieExpirationDate = new Date(Date.now() + 365 * 24 * 60 * 60 * 1000);
+            const langCookieExpirationDate = 365 * 24 * 60 * 60 * 1000;
             setCookie("language", newLanguage, langCookieExpirationDate);
         }
     };


### PR DESCRIPTION
Fix language cookie expiration calculation in SettingsPage: update langCookieExpirationDate to directly use the expiration duration in milliseconds for improved clarity and correctness.
